### PR TITLE
style 💎: disable transition effect

### DIFF
--- a/app/dashboard/patient/layout.tsx
+++ b/app/dashboard/patient/layout.tsx
@@ -59,7 +59,8 @@ const Layout: React.FC<RNChildProp> = ({ children }: RNChildProp) => {
 									initial={{ opacity: 0, y: 20 }}
 									animate={{ opacity: 1, y: 0 }}
 									exit={{ opacity: 0, y: -20 }}
-									transition={{ duration: 0.2 }}>
+									// transition={{ duration: 0.2 }}
+								>
 									{children}
 								</motion.div>
 							</AnimatePresence>


### PR DESCRIPTION
- The primary change is to disable the transition effect on a motion div element by commenting out its configuration.