### PR TITLE
chore 📦: update lucide-react package

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "input-otp": "^1.4.2",
     "jquery": "^3.7.1",
     "jsonwebtoken": "^9.0.2",
-    "lucide-react": "^0.487.0",
+    "lucide-react": "^0.503.0",
     "next": "^15.3.1",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3419,7 +3419,7 @@ __metadata:
     input-otp: "npm:^1.4.2"
     jquery: "npm:^3.7.1"
     jsonwebtoken: "npm:^9.0.2"
-    lucide-react: "npm:^0.487.0"
+    lucide-react: "npm:^0.503.0"
     next: "npm:^15.3.1"
     next-auth: "npm:^4.24.11"
     next-themes: "npm:^0.4.6"
@@ -5069,12 +5069,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lucide-react@npm:^0.487.0":
-  version: 0.487.0
-  resolution: "lucide-react@npm:0.487.0"
+"lucide-react@npm:^0.503.0":
+  version: 0.503.0
+  resolution: "lucide-react@npm:0.503.0"
   peerDependencies:
     react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/7177778c584b8e9545957bef28e95841c4be1b3bf473f9e2e64454c3e183d7ed0bc977c9f7b5446088023c7000151b7a3b27398d4f70025bf343782192f653ca
+  checksum: 10c0/97d282acf1a384da690cd973804d11737ebdba744cd11b2a3807a06d407e0f1f975723d9ce4afcb55058e6bd179d77029272cddcc726232339a3fde263b375b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Updated lucide-react package to version 0.503.0 to ensure compatibility and latest features.
- The main goal of the changes is to update the lucide-react package from version 0.487.0 to 0.503.0.